### PR TITLE
Remove erroneous CATTLEFODDER flag from war horse in DDA.

### DIFF
--- a/Medieval_Mod_Reborn/monsters.json
+++ b/Medieval_Mod_Reborn/monsters.json
@@ -16,7 +16,6 @@
       "HEARS",
       "SMELLS",
       "ANIMAL",
-      "CATTLEFODDER",
       "PET_MOUNTABLE",
       "PATH_AVOID_DANGER_1",
       "WARM"


### PR DESCRIPTION
This flag is no longer present in DDA and throws an error
Other attributes (inherited from the normal horse) allow for feeding the war horse (tested with cattle fodder).