### PR TITLE
Pending BN update: use COMPACT flag for stuff

### DIFF
--- a/Medieval_Mod_Reborn_BN/items/armor.json
+++ b/Medieval_Mod_Reborn_BN/items/armor.json
@@ -57,7 +57,7 @@
     "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "WAIST", "SUPER_FANCY", "BLOCK_WHILE_WORN" ]
+    "flags": [ "WAIST", "COMPACT", "SUPER_FANCY", "BLOCK_WHILE_WORN" ]
   },
   {
     "id": "armor_samurai_tosei",


### PR DESCRIPTION
Set aside as a draft for if https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3792 is merged. Just adds the `COMPACT` flag to ornamental wings.