### PR TITLE
Pending BN update: superalloy medieval armor

### DIFF
--- a/Medieval_Mod_Reborn_BN/items/armor.json
+++ b/Medieval_Mod_Reborn_BN/items/armor.json
@@ -43,6 +43,18 @@
     "flags": [ "FANCY", "VARSIZE", "STURDY", "SUN_GLASSES" ]
   },
   {
+    "id": "helmet_szyszak_superalloy",
+    "copy-from": "helmet_szyszak",
+    "type": "ARMOR",
+    "name": { "str": "superalloy szyszak", "str_pl": "superalloy szyszaki" },
+    "description": "A post-Renaissance type of lobster-tailed helmet with an ornate crest, short brim, and well-decorated protection for the eyes and nose.  Now made even more stylish through the use of cutting-edge superalloy.",
+    "material": [ "superalloy", "leather" ],
+    "color": "light_cyan",
+    "//": "Superalloy armor uses 5 less encumbrance than base item",
+    "encumbrance": 25,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
+  },
+  {
     "id": "wings_ornamental",
     "type": "ARMOR",
     "name": { "str": "ornamental wings", "str_pl": "ornamental wings" },
@@ -83,6 +95,17 @@
     "flags": [ "VARSIZE", "STURDY", "OUTER" ]
   },
   {
+    "id": "armor_samurai_tosei_superalloy",
+    "copy-from": "armor_samurai_tosei",
+    "type": "ARMOR",
+    "name": { "str_sp": "superalloy Tosei-gusoku" },
+    "description": "Japanese samurai armor of the 16th Century with a futuristic makeover, incorporating then-modern designs and now-modern superalloy to provide greater protection.",
+    "material": [ "superalloy", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 10,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
+  },
+  {
     "id": "sabatons_plate",
     "type": "ARMOR",
     "name": { "str": "pair of sabatons", "str_pl": "pairs of sabatons" },
@@ -103,6 +126,17 @@
     "warmth": 5,
     "material_thickness": 4,
     "flags": [ "VARSIZE", "STURDY", "BELTED" ]
+  },
+  {
+    "id": "sabatons_plate_superalloy",
+    "copy-from": "sabatons_plate",
+    "type": "ARMOR",
+    "name": { "str": "pair of superalloy sabatons", "str_pl": "pairs of superalloy sabatons" },
+    "description": "A Swedish power me- no, a component of medieval plate armor, covering the feet.  Made using lightweight superalloy.  Can be worn over other boots.",
+    "material": [ "superalloy", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 20,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {
     "id": "demigloves_plate",
@@ -126,6 +160,17 @@
     "material_thickness": 4,
     "environmental_protection": 1,
     "flags": [ "VARSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS" ]
+  },
+  {
+    "id": "demigloves_plate_superalloy",
+    "copy-from": "demigloves_plate",
+    "type": "ARMOR",
+    "name": { "str": "pair of superalloy armored demi-gauntlets", "str_pl": "pairs of superalloy armored demi-gauntlets" },
+    "description": "A robust set of fingerless superalloy-plated gloves, offering less coverage in exchange for solid construction and greater dexterity.",
+    "material": [ "superalloy", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 10,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {
     "id": "helmet_closehelm",
@@ -166,6 +211,37 @@
       "menu_text": "Lower",
       "type": "transform",
       "target": "helmet_closehelm",
+      "msg": "You lower the visor of your helmet back down over your face."
+    }
+  },
+  {
+    "id": "helmet_closehelm_superalloy",
+    "copy-from": "helmet_closehelm",
+    "type": "ARMOR",
+    "name": { "str": "superalloy close helmet" },
+    "description": "A late medieval helmet that completely encloses the head, with a visor and bevor that can be lifted up.  Remade in modern superalloy for lighter weight.  Activate it to lift the visor, exposing your face.",
+    "material": [ "superalloy", "leather" ],
+    "color": "light_cyan",
+    "encumbrance": 30,
+    "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 },
+    "use_action": {
+      "menu_text": "Raise",
+      "type": "transform",
+      "target": "helmet_closehelm_superalloy_raised",
+      "msg": "You lift the visor of your helmet."
+    }
+  },
+  {
+    "id": "helmet_closehelm_superalloy_raised",
+    "copy-from": "helmet_closehelm_superalloy",
+    "type": "ARMOR",
+    "name": { "str": "superalloy close helmet (raised)", "str_pl": "superalloy close helmets (raised)" },
+    "description": "A late medieval helmet that completely encloses the head, with a visor and bevor that has currently been lifted up.  Remade in modern superalloy for lighter weight.  Activate it to lower the visor back down to cover the face.",
+    "covers": [ "head" ],
+    "use_action": {
+      "menu_text": "Lower",
+      "type": "transform",
+      "target": "helmet_closehelm_superalloy",
       "msg": "You lower the visor of your helmet back down over your face."
     }
   },

--- a/Medieval_Mod_Reborn_BN/recipes/recipe_armor.json
+++ b/Medieval_Mod_Reborn_BN/recipes/recipe_armor.json
@@ -13,7 +13,7 @@
     "components": [
       [ [ "scrap_bronze", 4 ] ],
       [ [ "2x4", 4 ], [ "wood_panel", 1 ] ],
-      [ [ "rag", 2 ], [ "felt_patch", 2 ], [ "fur", 2 ], [ "leather", 2 ] ]
+      [ [ "rag", 2 ], [ "felt_patch", 2 ], [ "fabric_hides_proper", 2, "LIST" ] ]
     ]
   },
   {
@@ -27,7 +27,21 @@
     "book_learn": [ [ "textbook_armwest", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 15 ], [ "steel_standard", 10 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 4 ], [ "leather", 4 ] ] ]
+    "components": [ [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
+  },
+  {
+    "result": "helmet_szyszak_superalloy",
+    "//": "Superalloy armor recipes use alloy sheets equal to steel lumps used, difficulty 2 levels higher (maxing out at 10)",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "fabrication",
+    "difficulty": 9,
+    "time": "540 m",
+    "book_learn": [ [ "textbook_armwest", 8 ] ],
+    "using": [ [ "blacksmithing_intermediate", 15 ] ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [ [ [ "alloy_sheet", 10 ] ], [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
     "result": "wings_ornamental",
@@ -41,7 +55,7 @@
     "book_learn": [ [ "tailor_portfolio", 4 ] ],
     "using": [ [ "filament", 30 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SEW", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ], [ "stick", 4 ] ], [ [ "nail", 10 ] ], [ [ "feather", 30 ] ] ]
+    "components": [ [ [ "wood_structural", 2, "LIST" ] ], [ [ "nail", 10 ] ], [ [ "feather", 30 ] ] ]
   },
   {
     "result": "armor_samurai_tosei",
@@ -53,7 +67,7 @@
     "time": "9 h 20 m",
     "book_learn": [ [ "textbook_armeast", 9 ] ],
     "using": [ [ "blacksmithing_advanced", 72 ], [ "steel_standard", 18 ] ],
-    "components": [ [ [ "fur", 28 ], [ "leather", 28 ] ], [ [ "rag", 10 ] ] ]
+    "components": [ [ [ "fabric_hides_proper", 28, "LIST" ] ], [ [ "rag", 10 ] ] ]
   },
   {
     "result": "armor_samurai_tosei",
@@ -66,7 +80,39 @@
     "time": "6 h 10 m",
     "book_learn": [ [ "textbook_armeast", 8 ] ],
     "using": [ [ "blacksmithing_advanced", 40 ], [ "steel_standard", 10 ] ],
-    "components": [ [ [ "cuirass_lightplate", 1 ] ], [ [ "fur", 22 ], [ "leather", 22 ] ], [ [ "rag", 10 ] ] ]
+    "components": [ [ [ "cuirass_lightplate", 1 ] ], [ [ "fabric_hides_proper", 22, "LIST" ] ], [ [ "rag", 10 ] ] ]
+  },
+  {
+    "result": "armor_samurai_tosei_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_SUIT",
+    "skill_used": "fabrication",
+    "difficulty": 10,
+    "time": "9 h 20 m",
+    "//": "Recipe difficulty capped at 10, booklearn still elevated as if it could go past 10",
+    "book_learn": [ [ "textbook_armeast", 10 ] ],
+    "using": [ [ "blacksmithing_advanced", 72 ] ],
+    "components": [ [ [ "alloy_sheet", 18 ] ], [ [ "fabric_hides_proper", 28, "LIST" ] ], [ [ "rag", 10 ] ] ]
+  },
+  {
+    "result": "armor_samurai_tosei_superalloy",
+    "type": "recipe",
+    "id_suffix": "from_cuirass",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_SUIT",
+    "skill_used": "fabrication",
+    "difficulty": 10,
+    "time": "6 h 10 m",
+    "//": "Recipe difficulty capped at 10, booklearn still elevated as if it could go past 10",
+    "book_learn": [ [ "textbook_armeast", 10 ] ],
+    "using": [ [ "blacksmithing_advanced", 40 ] ],
+    "components": [
+      [ [ "alloy_sheet", 10 ] ],
+      [ [ "cuirass_lightplate_superalloy", 1 ] ],
+      [ [ "fabric_hides_proper", 22, "LIST" ] ],
+      [ [ "rag", 10 ] ]
+    ]
   },
   {
     "result": "sabatons_plate",
@@ -78,7 +124,19 @@
     "time": "8 h",
     "book_learn": [ [ "textbook_armwest", 5 ] ],
     "using": [ [ "blacksmithing_advanced", 32 ], [ "steel_standard", 8 ] ],
-    "components": [ [ [ "fur", 12 ], [ "leather", 12 ] ] ]
+    "components": [ [ [ "fabric_hides_proper", 12, "LIST" ] ] ]
+  },
+  {
+    "result": "sabatons_plate_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_FEET",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "time": "8 h",
+    "book_learn": [ [ "textbook_armwest", 7 ] ],
+    "using": [ [ "blacksmithing_advanced", 32 ] ],
+    "components": [ [ [ "alloy_sheet", 8 ] ], [ [ "fabric_hides_proper", 12, "LIST" ] ] ]
   },
   {
     "result": "demigloves_plate",
@@ -90,7 +148,19 @@
     "time": "7 h",
     "book_learn": [ [ "textbook_armwest", 5 ] ],
     "using": [ [ "blacksmithing_advanced", 24 ], [ "steel_standard", 6 ] ],
-    "components": [ [ [ "fur", 5 ], [ "leather", 5 ] ] ]
+    "components": [ [ [ "fabric_hides_proper", 5, "LIST" ] ] ]
+  },
+  {
+    "result": "demigloves_plate_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HANDS",
+    "skill_used": "fabrication",
+    "difficulty": 9,
+    "time": "7 h",
+    "book_learn": [ [ "textbook_armwest", 7 ] ],
+    "using": [ [ "blacksmithing_advanced", 24 ] ],
+    "components": [ [ [ "alloy_sheet", 6 ] ], [ [ "fabric_hides_proper", 5, "LIST" ] ] ]
   },
   {
     "result": "helmet_closehelm",
@@ -103,7 +173,20 @@
     "book_learn": [ [ "textbook_armwest", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 48 ], [ "steel_standard", 12 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 4 ], [ "leather", 4 ] ] ]
+    "components": [ [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
+  },
+  {
+    "result": "helmet_closehelm_superalloy",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "fabrication",
+    "difficulty": 9,
+    "time": "9 h",
+    "book_learn": [ [ "textbook_armwest", 7 ] ],
+    "using": [ [ "blacksmithing_advanced", 48 ] ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [ [ [ "alloy_sheet", 12 ] ], [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
     "result": "helmet_kettle",
@@ -117,6 +200,6 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 2 ], [ "leather", 2 ] ] ]
+    "components": [ [ [ "fabric_hides_proper", 2, "LIST" ] ] ]
   }
 ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3956 is merged. Not really dependant on it, but it adds to what that's adding so would be good to ensure things are finalized on BN's end before making this ready.

Adds superalloy versions of the following items:
* Szyszak
* Tosei-gusoku
* Sabatons
* Armored demi-gauntlets
* Close helmet

Follows the same general conventions as the related BN PRs set: 60% the base item's weight, double the price/post-apoc price (when defined), 5 lower encumbrance (set explicitly for the time being due to bugs with relative and proportional); meanwhile the recipes use 2 higher fabrication skill (whether primary or secondary skill, maxing out at 10), 2 higher booklearn level, and call for 1 superalloy sheet per steel lump used in the recipe (or 1 alloy plate per steel plate, where relevant).

If people pester me for it I guess I could add DDA versions of this, but they already have wacky amounts of flavor variations on armor items by grades of steel alredy, and having superalloy versions of Medieval Mod Reborn items only would look odd unless I also bothered to add DDA versions of the vanilla armors being implemented in BN by the above PR.

MISC: Also belatedly starts making use of some crafting qualities specific ot BN.