### PR TITLE
Pending BN feature: more `ALLOWS_X` flags for mutations

### DIFF
--- a/Medieval_Mod_Reborn_BN/items/armor.json
+++ b/Medieval_Mod_Reborn_BN/items/armor.json
@@ -71,7 +71,7 @@
     "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "WAIST", "COMPACT", "SUPER_FANCY", "BLOCK_WHILE_WORN" ]
+    "flags": [ "WAIST", "COMPACT", "SUPER_FANCY", "BLOCK_WHILE_WORN", "ALLOWS_WING" ]
   },
   {
     "id": "armor_samurai_tosei",
@@ -125,7 +125,7 @@
     "encumbrance": 25,
     "warmth": 5,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "STURDY", "BELTED" ]
+    "flags": [ "VARSIZE", "STURDY", "BELTED", "ALLOWS_CLAWS_FOOT" ]
   },
   {
     "id": "sabatons_plate_superalloy",
@@ -159,7 +159,7 @@
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "VARSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ]
   },
   {
     "id": "demigloves_plate_superalloy",

--- a/Medieval_Mod_Reborn_BN/items/armor.json
+++ b/Medieval_Mod_Reborn_BN/items/armor.json
@@ -71,7 +71,7 @@
     "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "WAIST", "COMPACT", "SUPER_FANCY", "BLOCK_WHILE_WORN", "ALLOWS_WING" ]
+    "flags": [ "WAIST", "COMPACT", "SUPER_FANCY", "BLOCK_WHILE_WORN", "ALLOWS_WINGS" ]
   },
   {
     "id": "armor_samurai_tosei",

--- a/Medieval_Mod_Reborn_BN/modinfo.json
+++ b/Medieval_Mod_Reborn_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Medieval Mod Reborn",
     "authors": [ "Chaosvolt" ],
     "description": "The official replacement for and expansion of the Medieval and Historic Content mod, Bright Nights version.",
-    "version": "BN version, update 9/7/2025",
+    "version": "BN version, update 9/11/2025",
     "category": "items",
     "dependencies": [ "bn" ]
   }


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7205 is merged, adds relevant use new `ALLOWS_X` flags on items.